### PR TITLE
Make grep ignore special characters when selecting a device

### DIFF
--- a/rofi-sound-output-chooser
+++ b/rofi-sound-output-chooser
@@ -15,7 +15,7 @@ then
     # the output from the selection will be the desciption.  Save that for alerts
     desc="$*"
     # Figure out what the device name is based on the description passed
-    device=$(pactl list sinks|grep -C2 "Description: $desc"|grep Name|cut -d: -f2|xargs)
+    device=$(pactl list sinks|grep -C2 -F "Description: $desc"|grep Name|cut -d: -f2|xargs)
     # Try to set the default to the device chosen
     if pactl set-default-sink "$device"
     then


### PR DESCRIPTION
Add `-F ` grep flag to ignore special characters. 
I opened a discussion in [#1](https://github.com/kellya/rofi-sound/issues/1) if this could lead to any problem. Thanks! :) 