### PR TITLE
remove extraneous echo

### DIFF
--- a/rofi-sound-output-chooser
+++ b/rofi-sound-output-chooser
@@ -11,7 +11,6 @@ elif command -v dunstify > /dev/null 2>&1; then
 else
     SEND="/bin/false"
 fi
-echo $SEND
 
 # An option was passed, so let's check it
 if [ "$@" ]


### PR DESCRIPTION
Great script, this works perfectly for my use case.

The only issue I had is that I get an extra item in rofi `notify-send` and rofi reopens with that as the only option after selecting the audio device, requiring a manual exit (esc key). 

Removing this `echo` line solves the issue for me.